### PR TITLE
Fix to instanced region IDs

### DIFF
--- a/src/main/java/com/projectileoverride/BossProjectiles.java
+++ b/src/main/java/com/projectileoverride/BossProjectiles.java
@@ -21,6 +21,7 @@ public enum BossProjectiles
     KALPHITE_QUEEN("Kalphite Queen", 280, 288),
     KREE_ARRA("Kree Arra", 1200, 1199),
     LEVIATHAN("Leviathan", 2489, 2487, 2488),
+    MAGGOT_KING("Maggot King", 3445, 1555),
     MANTICORE("Manticore", 2681, 2683, 2685),
 	OLM("Olm", 1341, 1343, 1345),
 	SCURRIUS("Scurrius", 2640, 2642),

--- a/src/main/java/com/projectileoverride/BossProjectiles.java
+++ b/src/main/java/com/projectileoverride/BossProjectiles.java
@@ -21,7 +21,7 @@ public enum BossProjectiles
     KALPHITE_QUEEN("Kalphite Queen", 280, 288),
     KREE_ARRA("Kree Arra", 1200, 1199),
     LEVIATHAN("Leviathan", 2489, 2487, 2488),
-    MAGGOT_KING("Maggot King", 3445, 1555),
+    MAGGOT_KING("Maggot King", 3445, 1555, new int[] { 11645 }),
     MANTICORE("Manticore", 2681, 2683, 2685),
 	OLM("Olm", 1341, 1343, 1345),
 	SCURRIUS("Scurrius", 2640, 2642),

--- a/src/main/java/com/projectileoverride/ProjectileOverride.java
+++ b/src/main/java/com/projectileoverride/ProjectileOverride.java
@@ -1,7 +1,10 @@
 package com.projectileoverride;
 
 import lombok.Getter;
+import net.runelite.api.Client;
 import net.runelite.api.Projectile;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 
 public class ProjectileOverride
 {
@@ -26,18 +29,30 @@ public class ProjectileOverride
         return overrideProjectileId;
     }
 
-	public boolean canOverride(Projectile projectile) {
+	public boolean canOverride(Projectile projectile, Client client) {
 		if (requiredRegion == null || requiredRegion.length == 0) {
 			return true;
 		}
 
-		for (int regionId: requiredRegion)
-		{
-			if (projectile.getSourcePoint().getRegionID() == regionId) {
+		// Whenever in an instance, the projectile.getSourcePoint().getRegionID() returns the instanced
+		// region ID, which changes any time you enter a new instance.
+		// This helps us to obtain the actual map region ID.
+		final int regionFromInstance = getRegionFromInstance(client);
+
+		for (int regionId : requiredRegion) {
+			if (projectile.getSourcePoint().getRegionID() == regionId || regionFromInstance == regionId) {
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	private int getRegionFromInstance(Client client) {
+		if (client.getLocalPlayer() == null) {
+			return -1;
+		}
+		LocalPoint playerInstancePoint = client.getLocalPlayer().getLocalLocation();
+		return WorldPoint.fromLocalInstance(client, playerInstancePoint).getRegionID();
 	}
 }

--- a/src/main/java/com/projectileoverride/ProjectileOverrideConfig.java
+++ b/src/main/java/com/projectileoverride/ProjectileOverrideConfig.java
@@ -138,6 +138,15 @@ public interface ProjectileOverrideConfig extends Config
 		return BossProjectiles.DEFAULT;
 	}
 
+	@ConfigItem(
+			keyName = "maggot-king",
+			name = "Maggot King",
+			description = "Projectile override for Maggot King"
+	)
+	default BossProjectiles MaggotKing() {
+		return BossProjectiles.DEFAULT;
+	}
+
     @ConfigItem(
         keyName = "manticore",
         name = "Manticore",

--- a/src/main/java/com/projectileoverride/ProjectileOverrideConfig.java
+++ b/src/main/java/com/projectileoverride/ProjectileOverrideConfig.java
@@ -159,15 +159,6 @@ public interface ProjectileOverrideConfig extends Config
 		return BossProjectiles.DEFAULT;
 	}
 
-	@ConfigItem(
-			keyName = "maggot-king",
-			name = "Maggot King",
-			description = "Projectile override for Maggot King"
-	)
-	default BossProjectiles MaggotKing() {
-		return BossProjectiles.DEFAULT;
-	}
-
     @ConfigItem(
         keyName = "manticore",
         name = "Manticore",

--- a/src/main/java/com/projectileoverride/ProjectileOverridePlugin.java
+++ b/src/main/java/com/projectileoverride/ProjectileOverridePlugin.java
@@ -70,7 +70,7 @@ public class ProjectileOverridePlugin extends Plugin
 
 		ProjectileOverride override = overrideMap.getOrDefault(projectile.getId(), null);
 
-		if (override != null && override.canOverride(projectile)) {
+		if (override != null && override.canOverride(projectile, client)) {
 			overriddenProjectiles.removeIf(p -> p.getRemainingCycles() < 0);
 			overriddenProjectiles.add(replaceProjectile(projectile, override));
 		}

--- a/src/main/java/com/projectileoverride/ProjectileOverridePlugin.java
+++ b/src/main/java/com/projectileoverride/ProjectileOverridePlugin.java
@@ -113,6 +113,7 @@ public class ProjectileOverridePlugin extends Plugin
         hydrateOverrideMap(BossProjectiles.KALPHITE_QUEEN, config.KalphiteQueen());
         hydrateOverrideMap(BossProjectiles.KREE_ARRA, config.KreeArra());
 		hydrateOverrideMap(BossProjectiles.LEVIATHAN, config.Leviathan());
+		hydrateOverrideMap(BossProjectiles.MAGGOT_KING, config.MaggotKing());
         hydrateOverrideMap(BossProjectiles.MANTICORE, config.Manticore());
 		hydrateOverrideMap(BossProjectiles.OLM, config.Olm());
 		hydrateOverrideMap(BossProjectiles.SCURRIUS, config.Scurrius());


### PR DESCRIPTION
Hey! This is related to PR #17.

I realized my previous PR introduced a bit of an issue: Maggot's magic attacks apparently share the same projectile ID as Doom's acid splashes from delve 3+. I originally tried to fix this by adding a region filter to Maggot, but that failed on Doom because the instanced region IDs don't match up with standard overworld IDs.

To fix this, this PR adds a secondary check to the canOverride function to evaluate the player's current region ID alongside the projectile's region. I had to use the player's position because I couldn't find an API method to convert the projectile's local region ID into a world point, so checking where the player is standing was the most reliable workaround.

Let me know what you think!